### PR TITLE
Fix Navbar scroll handler leak and update test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Node
+node_modules/
+
 # Distribution / packaging
 .Python
 build/

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the home page greeting', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const greetingElement = screen.getByText(/hi there/i);
+  expect(greetingElement).toBeInTheDocument();
 });

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Navbar from "react-bootstrap/Navbar";
 import Nav from "react-bootstrap/Nav";
 import Container from "react-bootstrap/Container";
@@ -26,7 +26,12 @@ function NavBar() {
     }
   }
 
-  window.addEventListener("scroll", scrollHandler);
+  useEffect(() => {
+    window.addEventListener("scroll", scrollHandler);
+    return () => {
+      window.removeEventListener("scroll", scrollHandler);
+    };
+  }, []);
 
   return (
     <Navbar


### PR DESCRIPTION
## Summary
- prevent repeated scroll listeners in `Navbar` by using `useEffect`
- update `App.test` to check for home page greeting
- ignore `node_modules` in git

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689667c1af1c832e83b45a1dffd29764